### PR TITLE
Partial back porting for 8223347: ../src/hotspot/share/opto/memnode.cpp

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -668,7 +668,8 @@ Node* MemNode::find_previous_store(PhaseTransform* phase) {
       }
 
       if (st_offset != offset && st_offset != Type::OffsetBot) {
-        const int MAX_STORE = BytesPerLong;
+        const int MAX_STORE = MAX2(BytesPerLong, (int)MaxVectorSize);
+        assert(mem->as_Store()->memory_size() <= MAX_STORE, "");
         if (st_offset >= offset + size_in_bytes ||
             st_offset <= offset - MAX_STORE ||
             st_offset <= offset - mem->as_Store()->memory_size()) {
@@ -1129,11 +1130,16 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseTransform* phase) const {
       // (This is one of the few places where a generic PhaseTransform
       // can create new nodes.  Think of it as lazily manifesting
       // virtually pre-existing constants.)
-      if (ReduceBulkZeroing || find_array_copy_clone(phase, ld_alloc, in(MemNode::Memory)) == NULL) {
-        // If ReduceBulkZeroing is disabled, we need to check if the allocation does not belong to an
-        // ArrayCopyNode clone. If it does, then we cannot assume zero since the initialization is done
-        // by the ArrayCopyNode.
-        return phase->zerocon(memory_type());
+      if (memory_type() != T_VOID) {
+        if (ReduceBulkZeroing || find_array_copy_clone(phase, ld_alloc, in(MemNode::Memory)) == NULL) {
+          // If ReduceBulkZeroing is disabled, we need to check if the allocation does not belong to an
+          // ArrayCopyNode clone. If it does, then we cannot assume zero since the initialization is done
+          // by the ArrayCopyNode.
+          return phase->zerocon(memory_type());
+        }
+      } else {
+        // TODO: materialize all-zero vector constant
+        assert(!isa_Load() || as_Load()->type()->isa_vect(), "");
       }
     }
 
@@ -2568,6 +2574,8 @@ Node *StoreNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       assert(Opcode() == st->Opcode() ||
              st->Opcode() == Op_StoreVector ||
              Opcode() == Op_StoreVector ||
+             st->Opcode() == Op_StoreVectorScatter ||
+             Opcode() == Op_StoreVectorScatter ||
              phase->C->get_alias_index(adr_type()) == Compile::AliasIdxRaw ||
              (Opcode() == Op_StoreL && st->Opcode() == Op_StoreI) || // expanded ClearArrayNode
              (Opcode() == Op_StoreI && st->Opcode() == Op_StoreL) || // initialization by arraycopy
@@ -3764,7 +3772,7 @@ intptr_t InitializeNode::can_capture_store(StoreNode* st, PhaseTransform* phase,
 int InitializeNode::captured_store_insertion_point(intptr_t start,
                                                    int size_in_bytes,
                                                    PhaseTransform* phase) {
-  const int FAIL = 0, MAX_STORE = BytesPerLong;
+  const int FAIL = 0, MAX_STORE = MAX2(BytesPerLong, (int)MaxVectorSize);
 
   if (is_complete())
     return FAIL;                // arraycopy got here first; punt
@@ -3794,6 +3802,7 @@ int InitializeNode::captured_store_insertion_point(intptr_t start,
       }
       return -(int)i;           // not found; here is where to put it
     } else if (st_off < start) {
+      assert(st->as_Store()->memory_size() <= MAX_STORE, "");
       if (size_in_bytes != 0 &&
           start < st_off + MAX_STORE &&
           start < st_off + st->as_Store()->memory_size()) {


### PR DESCRIPTION
Only  back porting the differents in PR8223347. 
Below PR list is about C2 and vector which are not merged, need to do more investigation and then determine how to merge.

8161334: C2: Cast nodes hinder memory alias analysis

8235653: Clean-up BarrierSetC2

8227384: C2 compilation fails with "graph should be schedulable" when running with -XX:-EliminateLocks

8227407: ZGC: C2 loads and load barriers can get separated by safepoints

8213371: GC/C2 abstraction and cleanup to handle custom offset for GC memory accesses

8247218: Add default constructor to VectorSet to use Thread::current()->resource_area() as arena by default

8231412: C2: InitializeNode::detect_init_independence() bails out on simple IR shapes
Avoids early bailout of capturing a field store to remove unnecessary zeroing in simple methods containing only non-escaping objects.